### PR TITLE
[WIP] Add basic support for CIV6 on Epic

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playyourdamnturn",
   "productName": "Play Your Damn Turn Client",
-  "version": "1.3.10",
+  "version": "1.4.0",
   "description": "Desktop Client to assist with playing your damn turns.",
   "author": "playyourdamnturn.com",
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ngx-custom-validators": "^9.1.0",
     "ngx-markdown": "^9.1.1",
     "pako": "^1.0.11",
-    "pydt-shared": "^1.3.6",
+    "pydt-shared": "^1.4.0",
     "rollbar": "^2.16.2",
     "rxjs": "^6.5.3",
     "rxjs-tslint": "^0.1.8",

--- a/ui/playTurn/playTurn.component.ts
+++ b/ui/playTurn/playTurn.component.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs-extra';
 import * as mkdirp from 'mkdirp';
 import * as pako from 'pako';
 import * as path from 'path';
-import { GAMES, CIV6_GAME, Game, GameService, PlatformSaveLocation, SteamProfileMap } from 'pydt-shared';
+import { GAMES, CIV6_GAME, Game, GameService, PlatformSaveLocation, SteamProfileMap, GameStore } from 'pydt-shared';
 import { PydtSettings } from '../shared/pydtSettings';
 import { PlayTurnState } from './playTurnState.service';
 
@@ -59,7 +59,13 @@ export class PlayTurnComponent implements OnInit {
 
     try {
       const location: PlatformSaveLocation = this.civGame.saveLocations[process.platform];
-      this.saveDir = app.remote.app.getPath(location.basePath) + location.prefix + this.civGame.saveDirectory;
+      const gamesLocation = app.remote.app.getPath(location.basePath) + location.prefix;
+
+      const gameDirectory = (fs.existsSync(gamesLocation + this.civGame.gamePaths[GameStore.Epic])) ?
+        gamesLocation + this.civGame.gamePaths[GameStore.Epic] :
+        gamesLocation + this.civGame.gamePaths[GameStore.Steam];
+
+      this.saveDir = gameDirectory + this.civGame.savePath;
 
       if (!fs.existsSync(this.saveDir)) {
         mkdirp.sync(this.saveDir);


### PR DESCRIPTION
Partially closes pydt/client#38
Depends on https://github.com/pydt/shared/pull/3

Why:

* Epic Game Store has a game directory in a different location.  The
  client currently will create a game directory and download the file to
  the Steam location if running the game on Epic.

This change addresses the need by:

* If the Epic CIV6 directory exists, it will use this for the save
  directory.  Otherwise it was will default to the Steam location.

**WIP** This client was not actually built, or tested yet.  Assuming this approach is approved and https://github.com/pydt/shared/pull/3 is merged will continue with this.