### PR TITLE
Add option to hide the client window to the tray context menu

### DIFF
--- a/app/src/window.js
+++ b/app/src/window.js
@@ -34,6 +34,11 @@ const updateMenu = async () => {
         click: () => {
           win.show();
         },
+      },      {
+        label: "Hide Client",
+        click: () => {
+          win.hide();
+        },
       },
       {
         label: "Exit",


### PR DESCRIPTION
The context menu for the tray icon only has a "show" option, and double clicking the tray icon isn't available in Linux ([according to the Electron documentation](https://www.electronjs.org/docs/latest/api/tray#event-double-click-macos-windows)) and even if it were, the action is only bound to showing the window, not hiding it again. This means that in window managers that don't put a close button on the window, such as some tiling window managers, the only way to hide the client is to exit it and then restart it.

To resolve this, I added a "Hide Client" option to the context menu that hides the window.

It's the first time I've ever touched Electron code so there may be a better way to do this; please feel free to edit as you see fit.