### PR TITLE
Show PYDT client in macOS menu bar

### DIFF
--- a/app/src/window.js
+++ b/app/src/window.js
@@ -41,7 +41,7 @@ const updateMenu = async () => {
 
   // Hide dock icon on macOS
   if (process.platform == "darwin") {
-    app.dock.hide();
+    if (!win.isVisible()) app.dock.hide();
   }
 
   if (!appIcon) {
@@ -55,7 +55,15 @@ const updateMenu = async () => {
   const contextMenu = Menu.buildFromTemplate([
     {
       label: win.isVisible() ? "Hide Client" : "Show Client",
-      click: () => (win.isVisible() ? win.hide() : win.show()),
+      click: () => {
+        if (win.isVisible()) {
+          win.hide();
+          app.dock.hide();
+        } else {
+          win.show();
+          app.dock.show();
+        }
+      },
     },
     {
       label: "Exit",


### PR DESCRIPTION
This update adds the PYDT client to the macOS menu bar. This required some small updates to the icon loading so it will scale appropriately. The result is similar to the system tray behavior on Linux and Windows.