### PR TITLE
Build electron app for ARM64 Windows as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,15 @@
     "win": {
       "artifactName": "playyourdamnturn-win-${version}.${ext}",
       "executableName": "PydtClient",
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
+      ],
       "azureSignOptions": {
         "publisherName": "Rosack Software Solutions, LLC",
         "endpoint": "https://eus.codesigning.azure.net/",


### PR DESCRIPTION
This change builds the installer and app for ARM64 windows, as well as x64.

Though the app works alright today under emulation on ARM64 Windows devices, for the best experience it would be preferable for the app to be native.

The biggest downside of this change is that it increases the size of the installer from ~80MB to ~160MB since the installer will now bundle both electron runtimes. It is possible to mitigate this issue using an NSIS Web installer, which will only download the correct architecture binary on each user's machine, but I figured you would prefer the simplicity of this approach.

I tested this by building the installer locally and running it on ARM64 and x64 machines and observing that the correct version of the app was installed on each. Also verified that the size of the installation folder (AppData\Local\Programs\playyourdamnturn) did not increase, suggesting that the installer did not install both architectures onto all machines.