### PR TITLE
Add feature to allow skipping the intro cinematic and logo videos in Civ 6

### DIFF
--- a/app/src/civ6Installation.js
+++ b/app/src/civ6Installation.js
@@ -1,0 +1,90 @@
+import * as fs from "fs";
+import * as path from "path";
+import { execFileSync } from "child_process";
+
+// Locates the Civ 6 game install (the folder containing Base/). Windows only.
+
+const CIV6_STEAM_DIR = "Sid Meier's Civilization VI";
+
+const regQuery = (key, value) => {
+  try {
+    const out = execFileSync("reg", ["query", key, "/v", value], { encoding: "utf8", windowsHide: true });
+    const m = new RegExp(`${value}\\s+REG_SZ\\s+(.+)`, "i").exec(out);
+
+    return m ? m[1].trim() : null;
+  } catch {
+    return null;
+  }
+};
+
+const steamLibraries = () => {
+  const root =
+    regQuery("HKCU\\Software\\Valve\\Steam", "SteamPath") ||
+    regQuery("HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam", "InstallPath") ||
+    "C:\\Program Files (x86)\\Steam";
+  const libs = [root];
+
+  try {
+    const vdf = fs.readFileSync(path.join(root, "steamapps", "libraryfolders.vdf"), "utf8");
+
+    for (const m of vdf.matchAll(/"path"\s+"([^"]+)"/g)) {
+      libs.push(m[1].replace(/\\\\/g, "\\"));
+    }
+  } catch {
+    // No extra libraries
+  }
+
+  return libs;
+};
+
+const findSteamCiv6 = () =>
+  steamLibraries()
+    .map(lib => path.join(lib, "steamapps", "common", CIV6_STEAM_DIR))
+    .find(p => fs.existsSync(p)) || null;
+
+const findEpicCiv6 = () => {
+  const manifests = path.join(
+    process.env.ProgramData || "C:\\ProgramData",
+    "Epic",
+    "EpicGamesLauncher",
+    "Data",
+    "Manifests",
+  );
+
+  try {
+    for (const f of fs.readdirSync(manifests)) {
+      if (!f.endsWith(".item")) {
+        continue;
+      }
+
+      try {
+        const item = JSON.parse(fs.readFileSync(path.join(manifests, f), "utf8"));
+
+        if (
+          /civilization vi\b/i.test(item.DisplayName || "") &&
+          item.InstallLocation &&
+          fs.existsSync(item.InstallLocation)
+        ) {
+          return item.InstallLocation;
+        }
+      } catch {
+        // Malformed manifest
+      }
+    }
+  } catch {
+    // No Epic launcher
+  }
+
+  return null;
+};
+
+// Windows only, find the installation folder for Civ 6
+export const findGameInstallDir = dataPath => {
+  if (process.platform !== "win32") {
+    return null;
+  }
+
+  const epic = /\(Epic\)$/i.test(path.basename(dataPath));
+
+  return (epic ? findEpicCiv6() : findSteamCiv6()) || findSteamCiv6() || findEpicCiv6();
+};

--- a/app/src/civ6Installation.js
+++ b/app/src/civ6Installation.js
@@ -6,7 +6,13 @@ import { execFileSync } from "child_process";
 
 const CIV6_STEAM_DIR = "Sid Meier's Civilization VI";
 
+const isWindows = () => process.platform === "win32";
+
 const regQuery = (key, value) => {
+  if (!isWindows()) {
+    return null;
+  }
+
   try {
     const out = execFileSync("reg", ["query", key, "/v", value], { encoding: "utf8", windowsHide: true });
     const m = new RegExp(`${value}\\s+REG_SZ\\s+(.+)`, "i").exec(out);
@@ -18,6 +24,10 @@ const regQuery = (key, value) => {
 };
 
 const steamLibraries = () => {
+  if (!isWindows()) {
+    return [];
+  }
+
   const root =
     regQuery("HKCU\\Software\\Valve\\Steam", "SteamPath") ||
     regQuery("HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam", "InstallPath") ||
@@ -37,12 +47,23 @@ const steamLibraries = () => {
   return libs;
 };
 
-const findSteamCiv6 = () =>
-  steamLibraries()
-    .map(lib => path.join(lib, "steamapps", "common", CIV6_STEAM_DIR))
-    .find(p => fs.existsSync(p)) || null;
+const findSteamCiv6 = () => {
+  if (!isWindows()) {
+    return null;
+  }
+
+  return (
+    steamLibraries()
+      .map(lib => path.join(lib, "steamapps", "common", CIV6_STEAM_DIR))
+      .find(p => fs.existsSync(p)) || null
+  );
+};
 
 const findEpicCiv6 = () => {
+  if (!isWindows()) {
+    return null;
+  }
+
   const manifests = path.join(
     process.env.ProgramData || "C:\\ProgramData",
     "Epic",
@@ -79,8 +100,8 @@ const findEpicCiv6 = () => {
 };
 
 // Windows only, find the installation folder for Civ 6
-export const findGameInstallDir = dataPath => {
-  if (process.platform !== "win32") {
+export const findCiv6InstallDir = dataPath => {
+  if (!isWindows()) {
     return null;
   }
 

--- a/app/src/civ6IntroSkip.js
+++ b/app/src/civ6IntroSkip.js
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { default as log } from "electron-log";
 import { RPC_INVOKE } from "./rpcChannels.js";
-import { findGameInstallDir } from "./civ6Installation.js";
+import { findCiv6InstallDir } from "./civ6Installation.js";
 import {
   findAppOptionsPath,
   getAppOption,
@@ -28,7 +28,7 @@ const REVERT_POLL_MS = 10 * 1000;
 const REVERT_MAX_MS = 6 * 60 * 60 * 1000;
 
 export const logoMoviePaths = dataPath => {
-  const install = findGameInstallDir(dataPath);
+  const install = findCiv6InstallDir(dataPath);
 
   if (!install) {
     return [];

--- a/app/src/civ6IntroSkip.js
+++ b/app/src/civ6IntroSkip.js
@@ -1,0 +1,298 @@
+import electron from "electron";
+import * as fs from "fs";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import { default as log } from "electron-log";
+import { RPC_INVOKE } from "./rpcChannels.js";
+import {
+  findAppOptionsPath,
+  getAppOption,
+  setAppOption,
+  readOptions,
+  writeOptions,
+  isCiv6Running,
+} from "./civ6Options.js";
+
+// Skip Civ 6's startup movies before launching a turn: set PlayIntroVideo 0 in AppOptions.txt
+// (same as the in-game option; set back to 1 when the setting is turned off).
+// For Windows we can go a step farther and prevent the game from opening the two logo
+// videos as well by holding open handles against them with exclusive read.
+
+const CIV6_STEAM_DIR = "Sid Meier's Civilization VI";
+const LOGO_MOVIES = ["logos.bk2", "LOGO_2KFiraxis.bk2"];
+
+const UV_FS_O_EXLOCK = 0x10000000; // Maps to FILE_SHARE_NONE on Windows
+const LOGO_LOCK_POLL_MS = 5 * 1000;
+const LOGO_LOCK_START_TIMEOUT_MS = 5 * 60 * 1000;
+const LOGO_LOCK_MAX_MS = 6 * 60 * 60 * 1000;
+const REVERT_POLL_MS = 10 * 1000;
+const REVERT_MAX_MS = 6 * 60 * 60 * 1000;
+
+const regQuery = (key, value) => {
+  try {
+    const out = execFileSync("reg", ["query", key, "/v", value], { encoding: "utf8", windowsHide: true });
+    const m = new RegExp(`${value}\\s+REG_SZ\\s+(.+)`, "i").exec(out);
+
+    return m ? m[1].trim() : null;
+  } catch {
+    return null;
+  }
+};
+
+const steamLibraries = () => {
+  const root =
+    regQuery("HKCU\\Software\\Valve\\Steam", "SteamPath") ||
+    regQuery("HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam", "InstallPath") ||
+    "C:\\Program Files (x86)\\Steam";
+  const libs = [root];
+
+  try {
+    const vdf = fs.readFileSync(path.join(root, "steamapps", "libraryfolders.vdf"), "utf8");
+
+    for (const m of vdf.matchAll(/"path"\s+"([^"]+)"/g)) {
+      libs.push(m[1].replace(/\\\\/g, "\\"));
+    }
+  } catch {
+    // No extra libraries
+  }
+
+  return libs;
+};
+
+const findSteamCiv6 = () =>
+  steamLibraries()
+    .map(lib => path.join(lib, "steamapps", "common", CIV6_STEAM_DIR))
+    .find(p => fs.existsSync(p)) || null;
+
+const findEpicCiv6 = () => {
+  const manifests = path.join(
+    process.env.ProgramData || "C:\\ProgramData",
+    "Epic",
+    "EpicGamesLauncher",
+    "Data",
+    "Manifests",
+  );
+
+  try {
+    for (const f of fs.readdirSync(manifests)) {
+      if (!f.endsWith(".item")) {
+        continue;
+      }
+
+      try {
+        const item = JSON.parse(fs.readFileSync(path.join(manifests, f), "utf8"));
+
+        if (
+          /civilization vi\b/i.test(item.DisplayName || "") &&
+          item.InstallLocation &&
+          fs.existsSync(item.InstallLocation)
+        ) {
+          return item.InstallLocation;
+        }
+      } catch {
+        // Malformed manifest
+      }
+    }
+  } catch {
+    // No Epic launcher
+  }
+
+  return null;
+};
+
+// Windows only, find the installation folder for Civ 6
+export const findGameInstallDir = dataPath => {
+  if (process.platform !== "win32") {
+    return null;
+  }
+
+  const epic = /\(Epic\)$/i.test(path.basename(dataPath));
+
+  return (epic ? findEpicCiv6() : findSteamCiv6()) || findSteamCiv6() || findEpicCiv6();
+};
+
+export const logoMoviePaths = dataPath => {
+  const install = findGameInstallDir(dataPath);
+
+  if (!install) {
+    return [];
+  }
+
+  return LOGO_MOVIES.map(m => path.join(install, "Base", "Platforms", "Windows", "Movies", m)).filter(p =>
+    fs.existsSync(p),
+  );
+};
+
+let logoLock = null; // { fds, timer }
+
+export const releaseLogoMovies = () => {
+  if (!logoLock) {
+    return false;
+  }
+
+  clearInterval(logoLock.timer);
+
+  for (const fd of logoLock.fds) {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      // Already closed
+    }
+  }
+
+  const count = logoLock.fds.length;
+  logoLock = null;
+  log.info(`Civ 6 intro skip: released ${count} logo movie lock(s)`);
+
+  return true;
+};
+
+// Released once the game has run and exited, if it never starts, or after a long timeout
+export const lockLogoMovies = dataPath => {
+  releaseLogoMovies();
+
+  const files = logoMoviePaths(dataPath);
+  const fds = [];
+
+  for (const file of files) {
+    try {
+      fds.push(fs.openSync(file, fs.constants.O_RDONLY | UV_FS_O_EXLOCK));
+    } catch (err) {
+      log.warn(`Civ 6 intro skip: could not lock ${file}: ${err.message}`);
+    }
+  }
+
+  if (!fds.length) {
+    return 0;
+  }
+
+  const startedAt = Date.now();
+  let seenRunning = false;
+
+  logoLock = {
+    fds,
+    timer: setInterval(() => {
+      const running = isCiv6Running();
+      const elapsed = Date.now() - startedAt;
+
+      if (running === true) {
+        seenRunning = true;
+      } else if (seenRunning || elapsed > LOGO_LOCK_START_TIMEOUT_MS) {
+        releaseLogoMovies();
+      }
+
+      if (logoLock && elapsed > LOGO_LOCK_MAX_MS) {
+        releaseLogoMovies();
+      }
+    }, LOGO_LOCK_POLL_MS),
+  };
+
+  log.info(`Civ 6 intro skip: locked ${fds.length} logo movie(s) in ${path.dirname(files[0])}`);
+
+  return fds.length;
+};
+
+// dataPath is the Civ 6 user data folder (parent of Saves/).
+export const prepareIntroSkip = ({ dataPath }) => {
+  try {
+    cancelPendingRevert();
+
+    const appOptionsPath = findAppOptionsPath(dataPath);
+    const notes = [];
+
+    if (appOptionsPath) {
+      const text = readOptions(appOptionsPath);
+
+      if (getAppOption(text, "PlayIntroVideo") !== "0") {
+        writeOptions(appOptionsPath, setAppOption(text, "Video", "PlayIntroVideo", "0"));
+        notes.push(`PlayIntroVideo=0 in ${appOptionsPath}`);
+      }
+    } else {
+      notes.push(`AppOptions.txt not found for ${dataPath} (has the game been run once?)`);
+    }
+
+    const locked = lockLogoMovies(dataPath);
+
+    if (locked) {
+      notes.push(`${locked} logo movie(s) locked`);
+    }
+
+    const message = `Civ 6 intro skip: ${notes.length ? notes.join("; ") : "nothing to do"}`;
+    log.info(message);
+
+    return { ok: true, message };
+  } catch (err) {
+    const message = `Civ 6 intro skip failed: ${err.message}`;
+    log.error(message);
+
+    return { ok: false, message };
+  }
+};
+
+// Turn the intro video back on once the setting is off.
+export const revertIntroSkip = ({ dataPath }) => {
+  try {
+    const notes = [];
+
+    if (releaseLogoMovies()) {
+      notes.push("logo movies released");
+    }
+
+    const appOptionsPath = findAppOptionsPath(dataPath);
+
+    if (appOptionsPath && getAppOption(readOptions(appOptionsPath), "PlayIntroVideo") === "0") {
+      if (isCiv6Running()) {
+        schedulePendingRevert(dataPath);
+        notes.push("Civ 6 is running; PlayIntroVideo will be restored when it exits");
+      } else {
+        writeOptions(appOptionsPath, setAppOption(readOptions(appOptionsPath), "Video", "PlayIntroVideo", "1"));
+        cancelPendingRevert();
+        notes.push(`PlayIntroVideo=1 in ${appOptionsPath}`);
+      }
+    }
+
+    const message = `Civ 6 intro skip revert: ${notes.length ? notes.join("; ") : "nothing to do"}`;
+    log.info(message);
+
+    return { ok: true, message };
+  } catch (err) {
+    const message = `Civ 6 intro skip revert failed: ${err.message}`;
+    log.error(message);
+
+    return { ok: false, message };
+  }
+};
+
+let pendingRevert = null;
+
+const cancelPendingRevert = () => {
+  if (pendingRevert) {
+    clearInterval(pendingRevert.timer);
+    pendingRevert = null;
+  }
+};
+
+const schedulePendingRevert = dataPath => {
+  if (pendingRevert) {
+    return;
+  }
+
+  const startedAt = Date.now();
+
+  pendingRevert = {
+    timer: setInterval(() => {
+      if (Date.now() - startedAt > REVERT_MAX_MS) {
+        log.warn("Civ 6 intro skip: gave up waiting for the game to exit");
+        cancelPendingRevert();
+        return;
+      }
+
+      if (isCiv6Running() !== true) {
+        revertIntroSkip({ dataPath });
+      }
+    }, REVERT_POLL_MS),
+  };
+};
+
+electron.ipcMain.handle(RPC_INVOKE.CIV6_INTRO_SKIP_PREPARE, (e, arg) => prepareIntroSkip(arg));
+electron.ipcMain.handle(RPC_INVOKE.CIV6_INTRO_SKIP_REVERT, (e, arg) => revertIntroSkip(arg));

--- a/app/src/civ6IntroSkip.js
+++ b/app/src/civ6IntroSkip.js
@@ -1,9 +1,9 @@
 import electron from "electron";
 import * as fs from "fs";
 import * as path from "path";
-import { execFileSync } from "child_process";
 import { default as log } from "electron-log";
 import { RPC_INVOKE } from "./rpcChannels.js";
+import { findGameInstallDir } from "./civ6Installation.js";
 import {
   findAppOptionsPath,
   getAppOption,
@@ -18,7 +18,6 @@ import {
 // For Windows we can go a step farther and prevent the game from opening the two logo
 // videos as well by holding open handles against them with exclusive read.
 
-const CIV6_STEAM_DIR = "Sid Meier's Civilization VI";
 const LOGO_MOVIES = ["logos.bk2", "LOGO_2KFiraxis.bk2"];
 
 const UV_FS_O_EXLOCK = 0x10000000; // Maps to FILE_SHARE_NONE on Windows
@@ -27,89 +26,6 @@ const LOGO_LOCK_START_TIMEOUT_MS = 5 * 60 * 1000;
 const LOGO_LOCK_MAX_MS = 6 * 60 * 60 * 1000;
 const REVERT_POLL_MS = 10 * 1000;
 const REVERT_MAX_MS = 6 * 60 * 60 * 1000;
-
-const regQuery = (key, value) => {
-  try {
-    const out = execFileSync("reg", ["query", key, "/v", value], { encoding: "utf8", windowsHide: true });
-    const m = new RegExp(`${value}\\s+REG_SZ\\s+(.+)`, "i").exec(out);
-
-    return m ? m[1].trim() : null;
-  } catch {
-    return null;
-  }
-};
-
-const steamLibraries = () => {
-  const root =
-    regQuery("HKCU\\Software\\Valve\\Steam", "SteamPath") ||
-    regQuery("HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam", "InstallPath") ||
-    "C:\\Program Files (x86)\\Steam";
-  const libs = [root];
-
-  try {
-    const vdf = fs.readFileSync(path.join(root, "steamapps", "libraryfolders.vdf"), "utf8");
-
-    for (const m of vdf.matchAll(/"path"\s+"([^"]+)"/g)) {
-      libs.push(m[1].replace(/\\\\/g, "\\"));
-    }
-  } catch {
-    // No extra libraries
-  }
-
-  return libs;
-};
-
-const findSteamCiv6 = () =>
-  steamLibraries()
-    .map(lib => path.join(lib, "steamapps", "common", CIV6_STEAM_DIR))
-    .find(p => fs.existsSync(p)) || null;
-
-const findEpicCiv6 = () => {
-  const manifests = path.join(
-    process.env.ProgramData || "C:\\ProgramData",
-    "Epic",
-    "EpicGamesLauncher",
-    "Data",
-    "Manifests",
-  );
-
-  try {
-    for (const f of fs.readdirSync(manifests)) {
-      if (!f.endsWith(".item")) {
-        continue;
-      }
-
-      try {
-        const item = JSON.parse(fs.readFileSync(path.join(manifests, f), "utf8"));
-
-        if (
-          /civilization vi\b/i.test(item.DisplayName || "") &&
-          item.InstallLocation &&
-          fs.existsSync(item.InstallLocation)
-        ) {
-          return item.InstallLocation;
-        }
-      } catch {
-        // Malformed manifest
-      }
-    }
-  } catch {
-    // No Epic launcher
-  }
-
-  return null;
-};
-
-// Windows only, find the installation folder for Civ 6
-export const findGameInstallDir = dataPath => {
-  if (process.platform !== "win32") {
-    return null;
-  }
-
-  const epic = /\(Epic\)$/i.test(path.basename(dataPath));
-
-  return (epic ? findEpicCiv6() : findSteamCiv6()) || findSteamCiv6() || findEpicCiv6();
-};
 
 export const logoMoviePaths = dataPath => {
   const install = findGameInstallDir(dataPath);

--- a/app/src/civ6Options.js
+++ b/app/src/civ6Options.js
@@ -1,0 +1,126 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import { default as log } from "electron-log";
+
+// Helpers for finding and editing Civ 6's AppOptions.txt, and checking whether the game is running
+
+const CIV6_DATA_DIR = "Sid Meier's Civilization VI";
+
+// Proton data paths look like .../compatdata/289070/pfx/drive_c/users/steamuser/Documents/My Games/...
+const PROTON_RE = /^(.*[\\/]pfx[\\/]drive_c)[\\/]users[\\/]([^\\/]+)[\\/]/i;
+
+const localAppData = () => process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local");
+
+const uniqueExisting = candidates => {
+  const seen = new Set();
+  const result = [];
+
+  for (const c of candidates) {
+    const n = path.normalize(c);
+
+    if (!seen.has(n)) {
+      seen.add(n);
+      result.push(n);
+    }
+  }
+
+  return result.find(p => fs.existsSync(p)) || null;
+};
+
+// Null if not found, which means the game has never been run
+export const findAppOptionsPath = dataPath => {
+  const dataDirName = path.basename(dataPath);
+  const proton = PROTON_RE.exec(dataPath);
+
+  if (proton) {
+    const [, driveC, user] = proton;
+    const firaxis = path.join(driveC, "users", user, "AppData", "Local", "Firaxis Games");
+
+    return uniqueExisting([
+      path.join(firaxis, dataDirName, "AppOptions.txt"),
+      path.join(firaxis, CIV6_DATA_DIR, "AppOptions.txt"),
+    ]);
+  }
+
+  switch (process.platform) {
+    case "win32":
+      return uniqueExisting([
+        path.join(localAppData(), "Firaxis Games", dataDirName, "AppOptions.txt"),
+        path.join(localAppData(), "Firaxis Games", CIV6_DATA_DIR, "AppOptions.txt"),
+      ]);
+
+    case "darwin":
+      // Lives next to the Saves folder in ~/Library/Application Support/<game>/
+      return uniqueExisting([
+        path.join(path.dirname(dataPath), "AppOptions.txt"),
+        path.join(dataPath, "AppOptions.txt"),
+      ]);
+
+    default:
+      // Native Linux keeps everything under ~/.local/share/aspyr-media/<game>/
+      return uniqueExisting([
+        path.join(dataPath, "AppOptions.txt"),
+        path.join(path.dirname(dataPath), "AppOptions.txt"),
+      ]);
+  }
+};
+
+const optionRe = key => new RegExp(`^${key}\\b[ \\t]*([^\\r\\n]*)`, "m");
+
+// "" if the key is blank, null if it's absent
+export const getAppOption = (text, key) => {
+  const m = optionRe(key).exec(text);
+
+  return m ? m[1].trim() : null;
+};
+
+
+export const setAppOption = (text, section, key, value) => {
+  const line = `${key} ${value}`.trimEnd();
+  const eol = text.includes("\r\n") ? "\r\n" : "\n";
+  const keyRe = optionRe(key);
+
+  if (keyRe.test(text)) {
+    // Function replacer so "$" in the value isn't treated as a replacement pattern
+    return text.replace(keyRe, () => line);
+  }
+
+  const sectionRe = new RegExp(`^\\[${section}\\][^\\r\\n]*`, "m");
+  const sectionMatch = sectionRe.exec(text);
+
+  if (sectionMatch) {
+    const insertAt = sectionMatch.index + sectionMatch[0].length;
+
+    return `${text.slice(0, insertAt)}${eol}${line}${text.slice(insertAt)}`;
+  }
+
+  const sep = text.length && !text.endsWith("\n") ? eol : "";
+
+  return `${text}${sep}${eol}[${section}]${eol}${line}${eol}`;
+};
+
+export const readOptions = appOptionsPath => fs.readFileSync(appOptionsPath, "utf8");
+
+export const writeOptions = (appOptionsPath, text) => fs.writeFileSync(appOptionsPath, text, "utf8");
+
+// Null if the process list can't be read
+export const isCiv6Running = () => {
+  try {
+    if (process.platform === "win32") {
+      const out = execFileSync("tasklist", ["/FO", "CSV", "/NH"], { encoding: "utf8", windowsHide: true });
+
+      return /^"CivilizationVI[^"]*\.exe"/im.test(out);
+    }
+
+    // macOS: "Civilization VI"; native Linux: "CivilizationVI"; Proton: "CivilizationVI*.exe"
+    const out = execFileSync("ps", ["-axo", "comm="], { encoding: "utf8" });
+
+    return /civilization ?vi\b|\bciv6\b/i.test(out);
+  } catch (err) {
+    log.warn(`Could not read process list: ${err.message}`);
+
+    return null;
+  }
+};

--- a/app/src/civ6Options.js
+++ b/app/src/civ6Options.js
@@ -76,7 +76,6 @@ export const getAppOption = (text, key) => {
   return m ? m[1].trim() : null;
 };
 
-
 export const setAppOption = (text, section, key, value) => {
   const line = `${key} ${value}`.trimEnd();
   const eol = text.includes("\r\n") ? "\r\n" : "\n";

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -13,6 +13,7 @@ import { getConfig } from "./storage.js";
 import { STORAGE_CONFIG } from "./storageConfig.js";
 
 import "./notifications.js";
+import "./civ6IntroSkip.js";
 
 contextMenu({
   showLookUpSelection: false,

--- a/ui/app.component.html
+++ b/ui/app.component.html
@@ -176,6 +176,27 @@
                 </p>
               </div>
             </div>
+            @if (civGame.id === CIV6_GAME_ID) {
+              <div class="form-check mt-3">
+                <input
+                  class="form-check-input"
+                  type="checkbox"
+                  name="civ6SkipIntroVideo"
+                  [(ngModel)]="settings.civ6SkipIntroVideo"
+                  [disabled]="!settings.launchCiv"
+                  id="civ6SkipIntroVideo"
+                />
+                <label class="form-check-label" for="civ6SkipIntroVideo">
+                  Skip the intro videos
+                  <small class="text-body-secondary d-block">
+                    Turns the intro cinematic off in the game's options. On Windows the logo reels are skipped too.
+                    @if (!settings.launchCiv) {
+                      <span class="d-block">Enable "Automatically launch Civ" on the General tab to use this.</span>
+                    }
+                  </small>
+                </label>
+              </div>
+            }
           </tab>
         }
       </tabset>

--- a/ui/app.component.ts
+++ b/ui/app.component.ts
@@ -1,7 +1,7 @@
 import { Component, NgZone, OnInit, ViewChild, TemplateRef, inject } from "@angular/core";
 import { BsModalRef, BsModalService, ModalOptions } from "ngx-bootstrap/modal";
 import { CivGame, GameStore } from "pydt-shared";
-import { PydtSettingsData, PydtSettingsFactory } from "./shared/pydtSettings";
+import { CIV6_GAME_ID, PydtSettingsData, PydtSettingsFactory } from "./shared/pydtSettings";
 import { RPC_INVOKE, RPC_TO_MAIN, RPC_TO_RENDERER } from "./rpcChannels";
 import { setTheme } from "ngx-bootstrap/utils";
 import { SafeMetadataLoader } from "./shared/safeMetadataLoader";
@@ -24,6 +24,7 @@ export class AppComponent implements OnInit {
   private updateService = inject(UpdateService);
   private router = inject(Router);
 
+  readonly CIV6_GAME_ID = CIV6_GAME_ID;
   version: string;
   newVersion: string;
   settings: PydtSettingsData;
@@ -131,6 +132,7 @@ export class AppComponent implements OnInit {
   async saveSettings(): Promise<void> {
     await this.settings.save();
     window.pydtApi.setAutostart(this.settings.startOnBoot);
+    await this.revertIntroSkipIfDisabled();
     window.pydtApi.ipc.send(RPC_TO_MAIN.SET_TURN_API_ENABLED, {
       enabled: this.settings.turnApiEnabled,
       port: this.settings.turnApiPort,
@@ -138,6 +140,26 @@ export class AppComponent implements OnInit {
     this.autoPlayEnabled = this.settings.autoPlay;
     this.pydtSettingsFactory.settingsChanged$.next();
     this.hideOpenModal();
+  }
+
+  // Turn the intro video back on
+  private async revertIntroSkipIfDisabled(): Promise<void> {
+    const civ6 = this.civGames?.find(x => x.id === CIV6_GAME_ID);
+
+    if (!civ6 || this.settings.shouldSkipCiv6Intro(civ6)) {
+      return;
+    }
+
+    const result = await window.pydtApi.ipc.invoke<{ ok: boolean; message: string }>(
+      RPC_INVOKE.CIV6_INTRO_SKIP_REVERT,
+      {
+        dataPath: this.settings.getDefaultDataPath(civ6),
+      },
+    );
+
+    if (!result?.ok) {
+      window.pydtApi.ipc.send(RPC_TO_MAIN.LOG_ERROR, `Could not restore Civ 6 intro video: ${result?.message}`);
+    }
   }
 
   async applyUpdate(): Promise<void> {

--- a/ui/playTurn/playTurn.component.ts
+++ b/ui/playTurn/playTurn.component.ts
@@ -6,7 +6,7 @@ import { PydtSettingsFactory, PydtSettingsData } from "../shared/pydtSettings";
 import { PlayTurnState } from "./playTurnState.service";
 import { TurnCacheService, TurnDownloader } from "../shared/turnCacheService";
 import { SafeMetadataLoader } from "../shared/safeMetadataLoader";
-import { RPC_TO_MAIN } from "../rpcChannels";
+import { RPC_INVOKE, RPC_TO_MAIN } from "../rpcChannels";
 import { Observable, Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { ProgressbarComponent } from "ngx-bootstrap/progressbar";
@@ -152,6 +152,7 @@ export class PlayTurnComponent implements OnInit, OnDestroy {
 
           await this.ngZone.run(async () => {
             if (this.settings.launchCiv) {
+              await this.prepareIntroSkip();
               window.pydtApi.ipc.send(RPC_TO_MAIN.OPEN_URL, url);
             }
 
@@ -181,6 +182,21 @@ export class PlayTurnComponent implements OnInit, OnDestroy {
     if (this.turnDownloader) {
       this.turnDownloader.abort();
       this.turnDownloader = null;
+    }
+  }
+
+  private async prepareIntroSkip(): Promise<void> {
+    if (!this.settings.shouldSkipCiv6Intro(this.civGame)) {
+      return;
+    }
+
+    const result = await window.pydtApi.ipc.invoke<{ ok: boolean; message: string }>(
+      RPC_INVOKE.CIV6_INTRO_SKIP_PREPARE,
+      { dataPath: this.settings.getDefaultDataPath(this.civGame) },
+    );
+
+    if (!result?.ok) {
+      window.pydtApi.ipc.send(RPC_TO_MAIN.LOG_ERROR, `Intro skip unavailable: ${result?.message}`);
     }
   }
 

--- a/ui/rpcChannels.ts
+++ b/ui/rpcChannels.ts
@@ -29,4 +29,6 @@ export enum RPC_INVOKE {
   SHOW_OPEN_DIALOG = "show-open-dialog",
   STORAGE_GET = "storage-get",
   STORAGE_SET = "storage-set",
+  CIV6_INTRO_SKIP_PREPARE = "civ6-intro-skip-prepare",
+  CIV6_INTRO_SKIP_REVERT = "civ6-intro-skip-revert",
 }

--- a/ui/shared/pydtSettings.ts
+++ b/ui/shared/pydtSettings.ts
@@ -17,6 +17,7 @@ export class PydtSettingsData {
   numSaves = 100;
   gameStores: { [index: string]: GameStore } = {};
   savePaths: { [index: string]: string } = {};
+  civ6SkipIntroVideo = true;
   autoDownload = false;
   autoPlay = false;
 
@@ -124,7 +125,13 @@ export class PydtSettingsData {
   setSavePath(civGame: CivGame, savePath: string): void {
     this.savePaths[civGame.id] = savePath;
   }
+
+  shouldSkipCiv6Intro(civGame: CivGame): boolean {
+    return civGame.id === CIV6_GAME_ID && this.launchCiv && this.civ6SkipIntroVideo;
+  }
 }
+
+export const CIV6_GAME_ID = "CIV6";
 
 @Injectable()
 export class PydtSettingsFactory {


### PR DESCRIPTION
This feature does two things:

1. It set the key PlayIntroVideo in AppOptions.txt to 0, which skips the long intro cinematic automatically (by default you have to click to skip it)
2. On Windows machines, we can also skip the two unskippable logos (Activision and 2K) which play before this cinematic. To accomplish this we first search for the Civ 6 installation, and then when the player's turn starts we "lock" those videos files with exclusive handles, preventing the game from opening them. A similar technique is possible in MacOS and Linux by changing file permissions with chmod, but that would technically be modifying the game on disk which seems risky.

This is just a nice convenience feature that I have wanted, since I often take my turns over RDP on cellular connections. It also lays some groundwork for another feature I am working on that automatically loads your hotseat save for you.